### PR TITLE
Index.html update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # last sleirsgoevy host for 7.02
 
+# v5.1
+    Fixed the mira2.js reference in index.html mira2 loads correctly
+
 # v5
     Add Linux loader split 1GB & 3GB
     New design for the portal of the exploit
-
+    
 # v4
     Add Linux loader (thanks to @mircoho)
     Add more message about the succes rate of the exploit on PS4 model

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@ function DisplayCacheProgress(){setTimeout(function(){window.msgs.innerHTML="Pag
     </div>
 <center>
 <a href="payload702.html#f=ps4-hen-vtx-702.js"><button type="button"><B>JB+HEN</B></button></a> &nbsp; &nbsp;
-<a href="payload702.html#f=mira702/mira2.js.js"><button type="button"><B>JB+MIRA</B></button></a> &nbsp; &nbsp;
+<a href="payload702.html#f=mira702/mira2.js"><button type="button"><B>JB+MIRA</B></button></a> &nbsp; &nbsp;
 <a href="netcat702.html"><button type="button"><B>JB+NETCAT (LEGACY)</B></button></a> &nbsp; &nbsp;
 <a href="payload702.html"><button type="button"><B>JB+NETCAT</B></button></a> &nbsp; &nbsp;
 <a href="dumper.html"><button type="button"><B>DUMPER</B></button></a> &nbsp; &nbsp;

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ function DisplayCacheProgress(){setTimeout(function(){window.msgs.innerHTML="Pag
         </ol><br>
         <p><i>This exploit <b>does</b> crash and hang. Sometimes you even have to retry 10 times to get the
                 jailbreak.</i></p>
-        <p><b><i>Credits:</b> Synacktiv team for the WebKit exploit, @theflow for the kernel exploit, @ChendoChap for HEN, &lt;anonymous&gt; for 7.02 module dumps,<br>@tihmstar for 7.02 offsets in the Linux loader, 7.02 mod page by Chronoss</i></p></center>
+        <p><b><i>Credits:</b> Synacktiv team for the WebKit exploit, @theflow for the kernel exploit, @ChendoChap for HEN, &lt;anonymous&gt; for 7.02 module dumps,<br>@tihmstar for 7.02 offsets in the Linux loader, 7.02 mod page by Chronoss, fixed mira2 payload in index.html by Stinger101mg</i></p></center>
     </div>
 <center>
 <a href="payload702.html#f=ps4-hen-vtx-702.js"><button type="button"><B>JB+HEN</B></button></a> &nbsp; &nbsp;


### PR DESCRIPTION
Mira payload had *.js.js for an extension, changed to match the payload *.js name. Deployed the changes myself and mira2.js loads correctly.